### PR TITLE
[Issue]: Modpack closes with error 6 on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 FORGE: https://www.curseforge.com/minecraft/modpacks/Prominence
 
 FABRIC: https://www.curseforge.com/minecraft/modpacks/Prominence-Fabric
+


### PR DESCRIPTION
Since issues are disabled I'm just going to use this pull request.
When i try to start "Prominence II RPG" on my linux box, 
the following error log gets printed 
(btw. i have tested v2.8.6 and v2.8.7 same results):

https://mclo.gs/WQ3dbCG

Any help is wellcome