### PR TITLE
Redstone duplication bug.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,40 +36,35 @@ body:
         attributes:
             label: Operating System
             description: The operating system you were using when the bug occured
-            placeholder: Windows 11
+            value: Windows 10
         validations:
             required: true
-    -   type: dropdown
+    -   type: input
         attributes:
             label: Minecraft Version
             description: The version of Minecraft you were using when the bug occured
-            options:
-                - "Prominence I 1.19.2"
-                - "Prominence II 1.20.1"
+            value: "Prominence II 1.20.1"
         validations:
             required: true
-    -   type: dropdown
+    -   type: input
         attributes:
             label: Modloader
             description: The version of Minecraft you were using when the bug occured
-            options:
-                - "Forge"
-                - "Fabric"
+            value: "Fabric"
         validations:
             required: true
     -   type: input
         attributes:
             label: Modpack Version
             description: The Modpack version you where using example bmc v52
+            value: "Prominence || RPG v3.0.21"
         validations:
             required: true
-    -   type: dropdown
+    -   type: input
         attributes:
             label: Optifine
             description: Did you used Optifine in our packs?
-            options:
-                - "I used Optifine"
-                - "No"
+            value: "No"
         validations:
             required: true
     -   type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,8 +5,8 @@ body:
     -   type: textarea
         attributes:
             label: Describe the Bug.
-            description: There is a way to duplicate redstone using available craft and gringers from tech mod.
-            value: | There is a way to duplicate redstone using available craft and gringers from tech mods.
+            description: A clear and concise description of what the bug is.
+            value: There is a way to duplicate redstone using available craft and gringers from tech mods.
         validations:
             required: true
     -   type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,6 +24,7 @@ body:
         attributes:
             label: Screenshots and Videos
             description: If applicable, add screenshots or videos to help explain your problem
+            value: attached to pull request.
         validations:
             required: false
     -   type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,8 +4,8 @@ labels: [ "bug" ]
 body:
     -   type: textarea
         attributes:
-            label: Describe the Bug
-            description: A clear and concise description of what the bug is
+            label: Redstone duplication bug.
+            description: There is a way to duplicate redstone using available craft and gringers from tech mods.
         validations:
             required: true
     -   type: textarea
@@ -13,9 +13,9 @@ body:
             label: Reproduction Steps
             description: Tell us about the steps to reproduce the bug
             value: |
-                1.
-                2.
-                3.
+                1. Craft "Raw Redstone Block" using 4 "Redstone".
+                2. Put "Raw Redstone Block" in "Grinder" and get 8 "redstone" or do the same with but with "Industrial grinder" or "Macerator"
+                3. Repeat process with output from step 2 to get endless source of "redstone"
                 ...
         validations:
             required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,10 +1,10 @@
-name: Bug Report
-description: Create a bug report to help us improve Prominence
+name: Redstone duplication bug.
+description: There is a way to duplicate redstone using available craft and gringers from tech mods.
 labels: [ "bug" ]
 body:
     -   type: textarea
         attributes:
-            label: Redstone duplication bug.
+            label: Describe the Bug.
             description: There is a way to duplicate redstone using available craft and gringers from tech mods.
         validations:
             required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,8 @@ body:
     -   type: textarea
         attributes:
             label: Describe the Bug.
-            description: There is a way to duplicate redstone using available craft and gringers from tech mods.
+            description: There is a way to duplicate redstone using available craft and gringers from tech mod.
+            value: | There is a way to duplicate redstone using available craft and gringers from tech mods.
         validations:
             required: true
     -   type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,8 +15,8 @@ body:
             description: Tell us about the steps to reproduce the bug
             value: |
                 1. Craft "Raw Redstone Block" using 4 "Redstone".
-                2. Put "Raw Redstone Block" in "Grinder" and get 8 "redstone" or do the same with but with "Industrial grinder" or "Macerator"
-                3. Repeat process with output from step 2 to get endless source of "redstone"
+                2. Put "Raw Redstone Block" in "Grinder" and get 8 "redstone" or do the same with "Industrial grinder" or "Macerator"
+                3. Repeat process.
                 ...
         validations:
             required: false
@@ -24,7 +24,7 @@ body:
         attributes:
             label: Screenshots and Videos
             description: If applicable, add screenshots or videos to help explain your problem
-            value: attached to pull request.
+            value: Attached to pull request.
         validations:
             required: false
     -   type: input


### PR DESCRIPTION
There is a way to duplicate redstone using mechanisms:

Steps to reproduce:

1. Craft Raw Redstone Block using 4 redstone.

 ![image](https://github.com/user-attachments/assets/9c124290-ea13-4ac6-b53f-7c8d1b921ef5)
 
 2. It counts as redstone ore, so you can put it in gringer and have 8 redstone as output.
  
![image](https://github.com/user-attachments/assets/9547a645-dba8-42d2-8280-247b962f7728)
![image](https://github.com/user-attachments/assets/e68732fb-5dfc-43ed-bde2-4eed603f4cf2)

3. Repeat process.
